### PR TITLE
Use getUri to maintain query parameters

### DIFF
--- a/src/Unpoly.php
+++ b/src/Unpoly.php
@@ -54,7 +54,7 @@ class Unpoly
     protected function echoRequestHeaders(Request $request, Response $response): void
     {
         $response->headers->add([
-            self::LOCATION_RESPONSE_HEADER => $request->getPathInfo(),
+            self::LOCATION_RESPONSE_HEADER => $request->getUri(),
             self::METHOD_RESPONSE_HEADER => $request->getMethod(),
         ]);
     }

--- a/tests/UnpolyTest.php
+++ b/tests/UnpolyTest.php
@@ -12,12 +12,12 @@ class UnpolyTest extends TestCase
 {
     public function testAppendsRequestHeadersToResponse()
     {
-        $request = Request::create('/foo/bar', 'PUT');
+        $request = Request::create('/foo/bar?param=baz', 'PUT');
         $response = new Response();
 
         (new Unpoly())->decorateResponse($request, $response);
 
-        $this->assertEquals('/foo/bar', $response->headers->get('X-Up-Location'));
+        $this->assertEquals('http://localhost/foo/bar?param=baz', $response->headers->get('X-Up-Location'));
         $this->assertEquals('PUT', $response->headers->get('X-Up-Method'));
     }
 


### PR DESCRIPTION
If only `getPathInfo()` is used, query parameters are lost. `getUri()` to includes query parameters allowing Unpoly to correctly update the URL when a link contains query parameters.

Prior to this change, clicking a link like:

```html
<a href="http://localhost/posts?page=2" up-follow>Next Page</a>
```

Would result in the URL staying:

```
http://localhost/posts
```

Related: https://github.com/unpoly/unpoly/issues/130