### PR TITLE
Added docs for other HTTP errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ protected function convertValidationExceptionToResponse(ValidationException $e, 
 
 #### Other HTTP Errors
 
-If your Laravel session expires and a user attempts to navigate or perform an operating on the page using Unpoly, an abrubt JSON error response will be displayed to the user:
+If your Laravel session expires and a user attempts to navigate or perform an operating on the page using Unpoly, an abrupt JSON error response will be displayed to the user:
 
 ```
 {'error': 'Unauthenticated.'}

--- a/README.md
+++ b/README.md
@@ -115,6 +115,51 @@ protected function convertValidationExceptionToResponse(ValidationException $e, 
 }
 ```
 
+#### Other HTTP Errors
+
+If your Laravel session expires and a user attempts to navigate or perform an operating on the page using Unpoly, a JSON error response will be returned:
+
+```
+{'error': 'Unauthenticated.'}
+```
+
+To prevent this, create your own `Request` and extend Laravel's built-in `Illuminate\Http\Request`, and override the `expectsJson` method:
+
+```php
+namespace App\Http;
+
+use Illuminate\Http\Request as BaseRequest;
+
+class Request extends BaseRequest
+{
+    public function expectsJson()
+    {
+        if ($this->hasHeader('X-Up-Target')) {
+            return false;
+        }
+
+        return parent::expectsJson();
+    }
+}
+```
+
+Then, navigate to your `public/index.php` file, and update the usage:
+
+
+```php
+// From...
+$response = $kernel->handle(
+    $request = Illuminate\Http\Request::capture()
+);
+
+// To...
+$response = $kernel->handle(
+    $request = App\Http\Request::capture()
+);
+```
+
+Now when a user session expires, the `<body>` of your page will be replaced with your login page, allowing users to sign back in without refreshing the page.
+
 ## Testing
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ protected function convertValidationExceptionToResponse(ValidationException $e, 
 
 #### Other HTTP Errors
 
-If your Laravel session expires and a user attempts to navigate or perform an operating on the page using Unpoly, a JSON error response will be returned:
+If your Laravel session expires and a user attempts to navigate or perform an operating on the page using Unpoly, an abrubt JSON error response will be displayed to the user:
 
 ```
 {'error': 'Unauthenticated.'}


### PR DESCRIPTION
This is needed when a user session expires (or other HTTP errors are thrown) in Laravel. Unpoly will swap the entire `<body>` of the document when an HTTP error occurs with the Laravel response, which will be a JSON "unauthenticated" message. I've looked at other ways of extending the `Illuminate\Http\Request`, but this appears to be the only way.

After this change though, Laravel will properly return a redirect response to the login page, which Unpoly will follow and grab the response from, displaying the login form and allowing users to login after their session has expired 👍