### PR TITLE
Add caret to symfony/http-kernel spec

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^8.0",
         "symfony/http-foundation": "^5.4|^6.0|^7.0",
-        "symfony/http-kernel": "^5.4|^6.0|7.0"
+        "symfony/http-kernel": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
Without this it is not possible to install the package. Adding a caret to the last version spec fixes the issue and the package is now installable.
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires webstronauts/unpoly dev-main -> satisfiable by webstronauts/unpoly[dev-main].
    - webstronauts/unpoly dev-main requires symfony/http-kernel ^5.4|^6.0|7.0 -> found symfony/http-kernel[v5.4.0, ..., v5.4.48, v6.0.0, ..., v6.4.16, v7.0.0] but these were not loaded, likely because it conflicts with another require.
```